### PR TITLE
Bump dependencies.

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,18 +9,13 @@ let
   in if try.success then
     builtins.trace "Using <hacknix>" try.value
   else
-    (import sources.hacknix);
+    sources.hacknix;
 
-  hacknix = fixedHacknix { };
+  hacknix = import fixedHacknix { };
   inherit (hacknix) lib;
 
-  # Override hacknix's nixpkgs for now, until this is resolved:
-  # https://github.com/input-output-hk/haskell.nix/issues/467
-  #inherit (lib.fetchers) fixedNixpkgs fixedNixOps;
-  #inherit (lib.hacknix) nixpkgs;
-  fixedNixpkgs =
-    lib.fetchers.fixedNixSrc "nixpkgs_override" sources.nixpkgs-unstable;
-  nixpkgs = import fixedNixpkgs;
+  inherit (lib.fetchers) fixedNixpkgs;
+  inherit (lib.hacknix) nixpkgs;
 
   fixedHaskellNix = lib.fetchers.fixedNixSrc "haskell-nix" sources.haskell-nix;
   haskellNix = import fixedHaskellNix;

--- a/nix/pkgs/cabal-fmt.nix
+++ b/nix/pkgs/cabal-fmt.nix
@@ -1,0 +1,35 @@
+{ lib
+, localLib
+, stdenv
+, pkgs
+, haskell-nix
+, config ? {}
+, enableLibraryProfiling ? false
+, enableExecutableProfiling ? false
+}:
+let
+  pkgSet = compiler:
+    let
+      ghc = haskell-nix.compiler.${compiler};
+    in haskell-nix.cabalProject {
+      src = localLib.sources.cabal-fmt;
+
+      pkg-def-extras = [];
+
+      modules = [
+        {
+          ghc.package = ghc;
+          compiler.version = pkgs.lib.mkForce ghc.version;
+          inherit enableLibraryProfiling enableExecutableProfiling;
+
+          packages.ghc.flags.ghci = pkgs.lib.mkForce true;
+          packages.ghci.flags.ghci = pkgs.lib.mkForce true;
+          reinstallableLibGhc = true;
+        }
+      ];
+    };
+in
+{
+  ghc865 = pkgSet "ghc865";
+  ghc883 = pkgSet "ghc883";
+}

--- a/nix/pkgs/cabal-fmt.nix
+++ b/nix/pkgs/cabal-fmt.nix
@@ -14,7 +14,16 @@ let
     in haskell-nix.cabalProject {
       src = localLib.sources.cabal-fmt;
 
-      pkg-def-extras = [];
+      pkg-def-extras = [
+        (
+          hackage: {
+            binary = hackage.binary."0.8.8.0".revisions.default;
+            parsec = hackage.parsec."3.1.14.0".revisions.default;
+            text = hackage.text."1.2.4.0".revisions.default;
+            time = hackage.time."1.9.3".revisions.default;
+          }
+        )
+      ];
 
       modules = [
         {

--- a/nix/pkgs/hls.nix
+++ b/nix/pkgs/hls.nix
@@ -1,13 +1,19 @@
-{ lib, localLib, stdenv, fetchFromGitHub, pkgs, haskell-nix, config ? { }
-, enableLibraryProfiling ? false, enableExecutableProfiling ? false }:
-
+{ lib
+, localLib
+, stdenv
+, fetchFromGitHub
+, pkgs
+, haskell-nix
+, config ? {}
+, enableLibraryProfiling ? false
+, enableExecutableProfiling ? false
+}:
 let
-
   src = fetchFromGitHub {
     owner = "haskell";
     repo = "haskell-language-server";
-    rev = "1f561043f2ea11237648768a9bdec093a8fb33e7";
-    sha256 = "0llqwl4v31jdxv41rp5izm6sxx6clwiz2n2bvdngrkcv6ycxdws1";
+    rev = "019b02831595b6a3be6776bfc56060ab918876e7";
+    sha256 = "1b0zlnmd43gzpz6dibpgczwq82vqj4yk3wb4q64dwkpyp3v7hi1x";
     fetchSubmodules = true;
   };
 
@@ -26,29 +32,33 @@ let
       inherit stackYaml;
 
       pkg-def-extras = [
-        (hackage: {
-          packages = {
-            "haskell-lsp" = hackage.haskell-lsp."0.20.0.1".revisions.default;
-          };
-        })
+        (
+          hackage: {
+            packages = {
+              "haskell-lsp" = hackage.haskell-lsp."0.21.0.0".revisions.default;
+            };
+          }
+        )
       ];
 
-      modules = [{
-        ghc.package = ghc;
-        compiler.version = pkgs.lib.mkForce ghc.version;
-        inherit enableLibraryProfiling enableExecutableProfiling;
+      modules = [
+        {
+          ghc.package = ghc;
+          compiler.version = pkgs.lib.mkForce ghc.version;
+          inherit enableLibraryProfiling enableExecutableProfiling;
 
-        packages.ghc.flags.ghci = pkgs.lib.mkForce true;
-        packages.ghci.flags.ghci = pkgs.lib.mkForce true;
-        reinstallableLibGhc = true;
-        packages.ghcide.configureFlags = [ "--enable-executable-dynamic" ];
+          packages.ghc.flags.ghci = pkgs.lib.mkForce true;
+          packages.ghci.flags.ghci = pkgs.lib.mkForce true;
+          reinstallableLibGhc = true;
+          packages.ghcide.configureFlags = [ "--enable-executable-dynamic" ];
 
-        # Haddock on haddock-api is broken :\
-        packages.haddock-api.components.library.doHaddock = lib.mkForce false;
-      }];
+          # Haddock on haddock-api is broken :\
+          packages.haddock-api.components.library.doHaddock = lib.mkForce false;
+        }
+      ];
     };
-
-in {
+in
+{
   ghc865 = pkgSet "ghc865";
   ghc883 = pkgSet "ghc883";
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "digital-asset",
         "repo": "ghcide",
-        "rev": "78d4031f7cf119bf2a0d1fae6157d52d1fbd2063",
-        "sha256": "0hhh0q4wv62g98a3c4l0d57jdmk4k1ilmzm2skr3b1w1y02ify24",
+        "rev": "6a650be7e32b221505bdad0548e8b570a03c8eb7",
+        "sha256": "1vzd81i2gpn2q2p1ah2bb57k014mb76rc84xrw3i39l49dda9rhn",
         "type": "tarball",
-        "url": "https://github.com/digital-asset/ghcide/archive/78d4031f7cf119bf2a0d1fae6157d52d1fbd2063.tar.gz",
+        "url": "https://github.com/digital-asset/ghcide/archive/6a650be7e32b221505bdad0548e8b570a03c8eb7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hacknix": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "c691370f8ea73d3428b4e7cd409e2ce8792d4f3a",
-        "sha256": "15pcxfhlf3f9mpcljnvhmv79ggi9bc3w59npmwb9zzrsfc246hc8",
+        "rev": "aa58eaa9aa0a3e8c922a8171d22db2037fd25d3d",
+        "sha256": "0wf4x89zfhlm70rkfjd4lcmv8k6zqm25pnmp3qpp5c9dbidgfqkw",
         "type": "tarball",
-        "url": "https://github.com/hackworthltd/hacknix/archive/c691370f8ea73d3428b4e7cd409e2ce8792d4f3a.tar.gz",
+        "url": "https://github.com/hackworthltd/hacknix/archive/aa58eaa9aa0a3e8c922a8171d22db2037fd25d3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-ide-engine": {
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "haskell",
         "repo": "haskell-ide-engine",
-        "rev": "6dc7d4302b3dd644163a318d66a2cebd29e37b0b",
-        "sha256": "04flivbh9wbzigaswpy6j13d186658yznmdjlm18xsfmxmjipg8k",
+        "rev": "d9d21fb0675280e20e837dbeb5715dab65e9c6be",
+        "sha256": "15i01h6c5j2dvdyfajbcby0q0mjaiqb9q2kg9wfjzzjm50khb7rg",
         "type": "tarball",
-        "url": "https://github.com/haskell/haskell-ide-engine/archive/6dc7d4302b3dd644163a318d66a2cebd29e37b0b.tar.gz",
+        "url": "https://github.com/haskell/haskell-ide-engine/archive/d9d21fb0675280e20e837dbeb5715dab65e9c6be.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix": {
@@ -53,10 +53,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "5813be54db841df0e756e5cfb436e7f9abbddbaf",
-        "sha256": "1396a7s7n1yhw6411mp1m7kmqsyp4a91yzy9449nfbrvn8s22qn7",
+        "rev": "ec3a9dad2a86fc3be07b85df4c0f4061d06b63a9",
+        "sha256": "0bijwhx0my20gk24h76j2wmqynry5m8890vz3qc5vpjr91dr7zlb",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/5813be54db841df0e756e5cfb436e7f9abbddbaf.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/ec3a9dad2a86fc3be07b85df4c0f4061d06b63a9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "tweag",
         "repo": "ormolu",
-        "rev": "22839ed74c9964578ae3b2af5c693f605ac8a687",
-        "sha256": "055z8p8kl80fr50crcvy2djk3qg2x34p8pa7kihxlcj9wrhsijyy",
+        "rev": "991bf8e24d9adf17a8461521ff62a6d4bd0709d5",
+        "sha256": "1c8g6i7plj5cpvbmn688dixy0n612vd140kriml6v1a832hckxdx",
         "type": "tarball",
-        "url": "https://github.com/tweag/ormolu/archive/22839ed74c9964578ae3b2af5c693f605ac8a687.tar.gz",
+        "url": "https://github.com/tweag/ormolu/archive/991bf8e24d9adf17a8461521ff62a6d4bd0709d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "cabal-fmt": {
+        "branch": "master",
+        "description": "An experiment of formatting .cabal files",
+        "homepage": null,
+        "owner": "phadej",
+        "repo": "cabal-fmt",
+        "rev": "2016b8fea5f65a67fc0f30e14cf76058614a1707",
+        "sha256": "1hycvih9cjb6cra1ss2n2scq8b2m50bgpndyijvvzibhf082x2yx",
+        "type": "tarball",
+        "url": "https://github.com/phadej/cabal-fmt/archive/2016b8fea5f65a67fc0f30e14cf76058614a1707.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "ghcide": {
         "branch": "master",
         "description": "A library for building Haskell IDE tooling",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "1f92cc15ca3621ba242d214c1d749e22f060a03b",
-        "sha256": "07zrcjxyvixvqjhbrl7ynpkbdwdkr07rq6imldf4hphvlaj9k4br",
+        "rev": "c691370f8ea73d3428b4e7cd409e2ce8792d4f3a",
+        "sha256": "15pcxfhlf3f9mpcljnvhmv79ggi9bc3w59npmwb9zzrsfc246hc8",
         "type": "tarball",
-        "url": "https://github.com/hackworthltd/hacknix/archive/1f92cc15ca3621ba242d214c1d749e22f060a03b.tar.gz",
+        "url": "https://github.com/hackworthltd/hacknix/archive/c691370f8ea73d3428b4e7cd409e2ce8792d4f3a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-ide-engine": {
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "701c83fb43179d303c06a3f60003ae68597ccebc",
-        "sha256": "0afpvi2av0y6fk97kd9mx8bprvfyiizxp22qrgar2ph9mfvaixdm",
+        "rev": "5813be54db841df0e756e5cfb436e7f9abbddbaf",
+        "sha256": "1396a7s7n1yhw6411mp1m7kmqsyp4a91yzy9449nfbrvn8s22qn7",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/701c83fb43179d303c06a3f60003ae68597ccebc.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/5813be54db841df0e756e5cfb436e7f9abbddbaf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -65,10 +65,10 @@
         "homepage": null,
         "owner": "tweag",
         "repo": "ormolu",
-        "rev": "3fbc130a0962ab236d87711beae1895d84a68362",
-        "sha256": "1gfdc5rc9jgwkx4y7gfqasl95nxkpmkgwj3489s3n9ws88dfragw",
+        "rev": "22839ed74c9964578ae3b2af5c693f605ac8a687",
+        "sha256": "055z8p8kl80fr50crcvy2djk3qg2x34p8pa7kihxlcj9wrhsijyy",
         "type": "tarball",
-        "url": "https://github.com/tweag/ormolu/archive/3fbc130a0962ab236d87711beae1895d84a68362.tar.gz",
+        "url": "https://github.com/tweag/ormolu/archive/22839ed74c9964578ae3b2af5c693f605ac8a687.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "digital-asset",
         "repo": "ghcide",
-        "rev": "39605333c34039241768a1809024c739df3fb2bd",
-        "sha256": "1iysrmj50w3w4ykv70ps6yr21x39mka80zpr9c8airzxb4930ar0",
+        "rev": "78d4031f7cf119bf2a0d1fae6157d52d1fbd2063",
+        "sha256": "0hhh0q4wv62g98a3c4l0d57jdmk4k1ilmzm2skr3b1w1y02ify24",
         "type": "tarball",
-        "url": "https://github.com/digital-asset/ghcide/archive/39605333c34039241768a1809024c739df3fb2bd.tar.gz",
+        "url": "https://github.com/digital-asset/ghcide/archive/78d4031f7cf119bf2a0d1fae6157d52d1fbd2063.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hacknix": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "0fb8e7760a296c0cec5eea6a8c77d78ca50b0806",
-        "sha256": "0blh55r322inq22kaq2b82z67x16qwkbdpvhamas7qwm0cciiisi",
+        "rev": "1f92cc15ca3621ba242d214c1d749e22f060a03b",
+        "sha256": "07zrcjxyvixvqjhbrl7ynpkbdwdkr07rq6imldf4hphvlaj9k4br",
         "type": "tarball",
-        "url": "https://github.com/hackworthltd/hacknix/archive/0fb8e7760a296c0cec5eea6a8c77d78ca50b0806.tar.gz",
+        "url": "https://github.com/hackworthltd/hacknix/archive/1f92cc15ca3621ba242d214c1d749e22f060a03b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-ide-engine": {
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d77ac3032d6f66d2bec28e2540f3d3b3321c80fa",
-        "sha256": "1h2d4z7j3frkxn961ill263kf6c1572dzfgvazpvvn6dciqairjm",
+        "rev": "701c83fb43179d303c06a3f60003ae68597ccebc",
+        "sha256": "0afpvi2av0y6fk97kd9mx8bprvfyiizxp22qrgar2ph9mfvaixdm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/d77ac3032d6f66d2bec28e2540f3d3b3321c80fa.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/701c83fb43179d303c06a3f60003ae68597ccebc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -59,28 +59,16 @@
         "url": "https://github.com/nmattia/niv/archive/f73bf8d584148677b01859677a63191c31911eae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "nixpkgs-unstable": {
-        "branch": "cc1ae9f21b9e0ce998e706a3de1bad0b5259f22d",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "cc1ae9f21b9e0ce998e706a3de1bad0b5259f22d",
-        "sha256": "0zjafww05h50ncapw51b5qxgbv9prjyag0j22jnfc3kcs5xr4ap0",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/cc1ae9f21b9e0ce998e706a3de1bad0b5259f22d.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "ormolu": {
         "branch": "master",
         "description": "A formatter for Haskell source code",
         "homepage": null,
         "owner": "tweag",
         "repo": "ormolu",
-        "rev": "d579a48f48cf732730fd958a2903c8a045dff146",
-        "sha256": "0hpzvmvf08hbzc1pzv8iy7lzx6dzv2908722a70j5wriaxvabdd5",
+        "rev": "3fbc130a0962ab236d87711beae1895d84a68362",
+        "sha256": "1gfdc5rc9jgwkx4y7gfqasl95nxkpmkgwj3489s3n9ws88dfragw",
         "type": "tarball",
-        "url": "https://github.com/tweag/ormolu/archive/d579a48f48cf732730fd958a2903c8a045dff146.tar.gz",
+        "url": "https://github.com/tweag/ormolu/archive/3fbc130a0962ab236d87711beae1895d84a68362.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
haskell.nix now works with recent nixpkgs, so we can undo the
nixpkgs-unstable hack.