### PR TITLE
Bump dependencies.

### DIFF
--- a/hhp/default.nix
+++ b/hhp/default.nix
@@ -39,7 +39,7 @@ let
   });
 
   ghc865Args = {
-    ghc = pkgs.haskell-nix.compiler.ghc865;
+    compiler-nix-name = "ghc865";
     inherit src;
     subdir = "hhp";
   };
@@ -47,7 +47,7 @@ let
   ghc865-profiled = mkProfiledSet ghc865Args;
 
   ghc883Args = {
-    ghc = pkgs.haskell-nix.compiler.ghc865;
+    compiler-nix-name = "ghc883";
     inherit src;
     subdir = "hhp";
     pkg-def-extras =

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -2,13 +2,16 @@ self: super:
 let
   hie = args:
     let
+      compiler = args.compiler-nix-name or (
+        if args.ghc.version == "8.6.5" then "ghc865" else if args.ghc.version == "8.8.3" then "ghc883" else abort "haskell-ide-engine: unsupported GHC version ${args.ghc.version}"
+      );
       stackYaml =
-        if args.ghc.version == "8.6.5" then
+        if compiler == "ghc865" then
           "stack-8.6.5.yaml"
-        else if args.ghc.version == "8.8.3" then
+        else if compiler == "ghc883" then
           "stack.yaml"
         else
-          abort "haskell-ide-engine: unsupported GHC version ${args.ghs.version}";
+          abort "haskell-ide-engine: unsupported GHC version ${compiler}";
     in
     (super.haskell-nix.stackProject (args // {
       name = "haskell-ide-engine";
@@ -36,13 +39,16 @@ let
 
   hls = args:
     let
+      compiler = args.compiler-nix-name or (
+        if args.ghc.version == "8.6.5" then "ghc865" else if args.ghc.version == "8.8.3" then "ghc883" else abort "haskell-ide-engine: unsupported GHC version ${args.ghc.version}"
+      );
       stackYaml =
-        if args.ghc.version == "8.6.5" then
+        if compiler == "ghc865" then
           "stack-8.6.5.yaml"
-        else if args.ghc.version == "8.8.3" then
+        else if compiler == "ghc883" then
           "stack-8.8.3.yaml"
         else
-          abort "haskell-language-server: unsupported GHC version ${args.ghs.version}";
+          abort "haskell-language-server: unsupported GHC version ${compiler}";
     in
     (super.haskell-nix.stackProject (args // {
       name = "haskell-language-server";
@@ -102,7 +108,7 @@ let
   #
   # These include any fixes needed for various haskell.nix issues.
   cabalProject =
-    { ghc
+    { compiler-nix-name
     , enableLibraryProfiling ? false
     , enableExecutableProfiling ? false
     , ...
@@ -116,7 +122,7 @@ let
       ];
       pkg-def-extras = (args.pkg-def-extras or [ ]) ++
         (
-          if ghc.version == "8.8.3" then [
+          if compiler-nix-name == "ghc883" then [
             (hackage: {
               alex = hackage.alex."3.2.5".revisions.default;
             })

--- a/nix/pkgs/cabal-fmt.nix
+++ b/nix/pkgs/cabal-fmt.nix
@@ -3,9 +3,9 @@
 , haskell-nix
 }:
 let
-  ghc = haskell-nix.compiler.ghc883;
   pkgSet =
     haskell-nix.cabalProject {
+      compiler-nix-name = "ghc883";
       src = localLib.sources.cabal-fmt;
 
       pkg-def-extras = [
@@ -21,9 +21,6 @@ let
 
       modules = [
         {
-          ghc.package = ghc;
-          compiler.version = pkgs.lib.mkForce ghc.version;
-
           packages.ghc.flags.ghci = pkgs.lib.mkForce true;
           packages.ghci.flags.ghci = pkgs.lib.mkForce true;
           reinstallableLibGhc = true;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "haskell",
         "repo": "haskell-ide-engine",
-        "rev": "e68018a652efa3d049614b303e452393d88253d6",
-        "sha256": "1v8hsmi6nyn1n8pcn6982gmf50yrgb402hj9xlc53x60a8d8sv1y",
+        "rev": "51b9739510b0ec013ff7c9959a67ac2d506838d5",
+        "sha256": "0y7fkim5hcwbmzwwlc2lv5rdalxwwg6xx8394ad65d2ahffm98qx",
         "type": "tarball",
-        "url": "https://github.com/haskell/haskell-ide-engine/archive/e68018a652efa3d049614b303e452393d88253d6.tar.gz",
+        "url": "https://github.com/haskell/haskell-ide-engine/archive/51b9739510b0ec013ff7c9959a67ac2d506838d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix": {
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "79b5458138b5411499191910fe77b789a4661239",
-        "sha256": "0v4zrwy0dqr6j7s08nbla570gf5x68xf6ncmwgghdp0ak5p2shdl",
+        "rev": "d43f6fcdd6a75b0c1561e988117a227454c75acb",
+        "sha256": "0bh5jik0gag0dlyfsg5n0j1n5k0xivivkgij8pxlz07a9g7m5mn9",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/79b5458138b5411499191910fe77b789a4661239.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/d43f6fcdd6a75b0c1561e988117a227454c75acb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
Note that haskell.nix has deprecated the `ghc` argument to
cabalProject, and has replaced it with `compiler-nix-name`, for better
cross-compiling support.

This commit also fixes a bug where the hhp ghc883 shell was actually
using ghc865.