### PR TITLE
ghcjs support.

### DIFF
--- a/hhp/default.nix
+++ b/hhp/default.nix
@@ -15,7 +15,7 @@ let
     collectTests collectChecks filterByPrefix;
 
   inherit (pkgs.haskell-hacknix)
-    cabalProject cache shellFor;
+    cabalProject cache shellFor ghcjsCabalProject ghcjsShellFor;
 
   src = pkgs.gitignoreSource ../.;
 
@@ -56,8 +56,28 @@ let
   ghc883 = mkSet ghc883Args;
   ghc883-profiled = mkProfiledSet ghc883Args;
 
+  ghcjs865 =
+    let
+      haskellPackages = ghcjsCabalProject ghc865Args;
+      shell = ghcjsShellFor haskellPackages { };
+      cachedShell = cache shell;
+    in
+    pkgs.recurseIntoAttrs {
+      inherit haskellPackages shell cachedShell;
+    };
+
+  ghcjs883 =
+    let
+      haskellPackages = ghcjsCabalProject ghc883Args;
+      shell = ghcjsShellFor haskellPackages { };
+      cachedShell = cache shell;
+    in
+    pkgs.recurseIntoAttrs {
+      inherit haskellPackages shell cachedShell;
+    };
 in
 {
   inherit ghc865 ghc865-profiled;
   inherit ghc883 ghc883-profiled;
+  inherit ghcjs865 ghcjs883;
 }

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -179,45 +179,6 @@ let
       modules = [
         {
           bootPkgs = [ "ghcjs-prim" ];
-          nonReinstallablePkgs = [
-            "Cabal"
-            "array"
-            "base"
-            "binary"
-            "bytestring"
-            "containers"
-            "deepseq"
-            "directory"
-            "filepath"
-            "ghc"
-            "ghc-boot"
-            "ghc-boot-th"
-            "ghc-compact"
-            "ghc-heap"
-            "ghc-prim"
-            "ghci"
-            "ghcjs-prim"
-            "ghcjs-th"
-            "integer-gmp"
-            "mtl"
-            "parsec"
-            "pretty"
-            "process"
-            "rts"
-            "template-haskell"
-            "text"
-            "time"
-            "transformers"
-            "unix"
-
-            "hpc"
-
-            # we can't build this one, so let's pretend it pre-exists.
-            "terminfo"
-
-            # This one is just absolutely broken.
-            "cabal-doctest"
-          ];
         }
       ];
       pkg-def-extras = (args.pkg-def-extras or [ ]) ++

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -200,12 +200,13 @@ let
         else abort "ghcjsShellFor: unsupported GHC version ${hp.compiler-nix-name}";
     in
     hp.shellFor (args // {
-      tools = {
-        cabal = { version = "3.2.0.0"; inherit compiler; };
-        hlint = { version = "3.1"; inherit compiler; };
-        ghcid = { version = "0.8.6"; inherit compiler; };
-        ormolu = { version = "0.0.5.0"; inherit compiler; };
-      } // (args.tools or { });
+      # Temporarily disable tools to get this to compile.
+      # tools = {
+      #   cabal = { version = "3.2.0.0"; inherit compiler; };
+      #   hlint = { version = "3.1"; inherit compiler; };
+      #   ghcid = { version = "0.8.6"; inherit compiler; };
+      #   ormolu = { version = "0.0.5.0"; inherit compiler; };
+      # } // (args.tools or { });
 
       buildInputs = [
         cabal-fmt

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a39af833318535ed4131201a96ca6e8eab005be5",
-        "sha256": "0fgv8mjm0ywgkj421qi9lkrabz86rvv5fya7lbkz5kin06jj8wdx",
+        "rev": "5f25ba3e57077ff271122a1b39dcaaa8dc2e4ed5",
+        "sha256": "07ivbavvr4zfsb3caam09qcr0yhwf05mbwk2cng8m3h7ha5nygmi",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/a39af833318535ed4131201a96ca6e8eab005be5.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/5f25ba3e57077ff271122a1b39dcaaa8dc2e4ed5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "60036cd8da5421a9e6815ad7714f61779facf78a",
-        "sha256": "01b75x8lh0zas30qa3mkhpj1nc05sqcwnq6djxga7a84bli9j57d",
+        "rev": "9c9608bb1da4d45b39042b5351a5ae32e90a17bc",
+        "sha256": "0c2x1byl6ijz0mk3chsdn8hss0cwjsbapmmchnh0mv1ig88141zw",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/60036cd8da5421a9e6815ad7714f61779facf78a.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/9c9608bb1da4d45b39042b5351a5ae32e90a17bc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1421e150a7aa040837bfc606da64ebe959a808b4",
-        "sha256": "00jm148qgzsws7lirwpihxyk5cx8q0hws6af260d4iln7kc6by21",
+        "rev": "78735bcb69d1957fd0277329ca10c40cd74dcc00",
+        "sha256": "15v1fq812lgxa4yjg295b4a3ni5agw5sj4yqfykyi9w248g5a5sp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/1421e150a7aa040837bfc606da64ebe959a808b4.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/78735bcb69d1957fd0277329ca10c40cd74dcc00.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,15 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix": {
-        "branch": "master",
+        "branch": "hkm/bundled-ghcjs",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d43f6fcdd6a75b0c1561e988117a227454c75acb",
-        "sha256": "0bh5jik0gag0dlyfsg5n0j1n5k0xivivkgij8pxlz07a9g7m5mn9",
+        "rev": "d13e0cc6317ab20234e0d4552201a9447a6e85ea",
+        "sha256": "0f340jkhnjggzc48avjz13i04bcz6dr2d2szpv9r94m8d8wxa2jd",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/d43f6fcdd6a75b0c1561e988117a227454c75acb.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/d13e0cc6317ab20234e0d4552201a9447a6e85ea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3ec897ca9d8b7a5e7f4e5637890ece22a0237bae",
-        "sha256": "1ar3rg1p60ay6ii4l21k2k2h9m616l9ksrym9vcb0gjjlxk8ss4x",
+        "rev": "a39af833318535ed4131201a96ca6e8eab005be5",
+        "sha256": "0fgv8mjm0ywgkj421qi9lkrabz86rvv5fya7lbkz5kin06jj8wdx",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/3ec897ca9d8b7a5e7f4e5637890ece22a0237bae.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/a39af833318535ed4131201a96ca6e8eab005be5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d13e0cc6317ab20234e0d4552201a9447a6e85ea",
-        "sha256": "0f340jkhnjggzc48avjz13i04bcz6dr2d2szpv9r94m8d8wxa2jd",
+        "rev": "3ec897ca9d8b7a5e7f4e5637890ece22a0237bae",
+        "sha256": "1ar3rg1p60ay6ii4l21k2k2h9m616l9ksrym9vcb0gjjlxk8ss4x",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/d13e0cc6317ab20234e0d4552201a9447a6e85ea.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/3ec897ca9d8b7a5e7f4e5637890ece22a0237bae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "5f25ba3e57077ff271122a1b39dcaaa8dc2e4ed5",
-        "sha256": "07ivbavvr4zfsb3caam09qcr0yhwf05mbwk2cng8m3h7ha5nygmi",
+        "rev": "60036cd8da5421a9e6815ad7714f61779facf78a",
+        "sha256": "01b75x8lh0zas30qa3mkhpj1nc05sqcwnq6djxga7a84bli9j57d",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/5f25ba3e57077ff271122a1b39dcaaa8dc2e4ed5.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/60036cd8da5421a9e6815ad7714f61779facf78a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "9c9608bb1da4d45b39042b5351a5ae32e90a17bc",
-        "sha256": "0c2x1byl6ijz0mk3chsdn8hss0cwjsbapmmchnh0mv1ig88141zw",
+        "rev": "1421e150a7aa040837bfc606da64ebe959a808b4",
+        "sha256": "00jm148qgzsws7lirwpihxyk5cx8q0hws6af260d4iln7kc6by21",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/9c9608bb1da4d45b39042b5351a5ae32e90a17bc.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/1421e150a7aa040837bfc606da64ebe959a808b4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
Note: shells do not include haskell-ide-engine as that needs to be
built with the same version of GHC as the compiled program, and that
doesn't make any sense with ghcjs.