### PR TITLE
Remove reinstallableLibGhc from all projects.

### DIFF
--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -16,7 +16,6 @@ let
         ({ config, ... }: {
           packages.ghc.flags.ghci = super.lib.mkForce true;
           packages.ghci.flags.ghci = super.lib.mkForce true;
-          reinstallableLibGhc = true;
 
           # Haddock on haddock-api is broken :\
           packages.haddock-api.components.library.doHaddock = super.lib.mkForce false;
@@ -79,9 +78,6 @@ let
     }@args:
     super.haskell-nix.cabalProject (args // {
       modules = (args.modules or [ ]) ++ [
-        # Workaround for doctest. See:
-        # https://github.com/input-output-hk/haskell.nix/issues/221
-        { reinstallableLibGhc = true; }
         { inherit enableLibraryProfiling enableExecutableProfiling; }
       ];
       pkg-def-extras = (args.pkg-def-extras or [ ]) ++

--- a/nix/pkgs/cabal-fmt.nix
+++ b/nix/pkgs/cabal-fmt.nix
@@ -23,7 +23,6 @@ let
         {
           packages.ghc.flags.ghci = pkgs.lib.mkForce true;
           packages.ghci.flags.ghci = pkgs.lib.mkForce true;
-          reinstallableLibGhc = true;
         }
       ];
     };


### PR DESCRIPTION
Looks like we don't need this anymore. It might still be needed for
doctest, but doctest has other issues with haskell.nix that prevent us
from using it currently, so let's try to wait until those are resolved.