### PR TITLE
Remove haskell-ide-engine support.

### DIFF
--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -1,29 +1,5 @@
 self: super:
 let
-  hie = args:
-    (super.haskell-nix.project (args // {
-      name = "haskell-ide-engine";
-      src = super.localLib.sources.haskell-ide-engine;
-      pkg-def-extras = [
-        (hackage: {
-          packages = {
-            "haskell-lsp" = hackage.haskell-lsp."0.20.0.1".revisions.default;
-          };
-        })
-      ];
-      projectFileName = "cabal.project";
-      modules = [
-        ({ config, ... }: {
-          packages.ghc.flags.ghci = super.lib.mkForce true;
-          packages.ghci.flags.ghci = super.lib.mkForce true;
-          reinstallableLibGhc = true;
-
-          # Haddock on haddock-api is broken :\
-          packages.haddock-api.components.library.doHaddock = super.lib.mkForce false;
-        })
-      ];
-    }));
-
   hls = args:
     (super.haskell-nix.project (args // {
       name = "haskell-language-server";
@@ -56,8 +32,6 @@ let
     }));
 
   extra-custom-tools = {
-    hie.latest = args: (hie args).haskell-ide-engine.components.exes.hie;
-    hie-wrapper.latest = args: (hie args).haskell-ide-engine.components.exes.hie-wrapper;
     hls.latest = args: (hls args).haskell-language-server.components.exes.haskell-language-server;
     hls-wrapper.latest = args: (hls args).haskell-language-server.components.exes.haskell-language-server-wrapper;
   };
@@ -135,7 +109,7 @@ let
         )
       ] ++ (args.buildInputs or [ ]);
 
-      # Help haskell-ide-engine find our Hoogle database. See:
+      # Help haskell-language-server find our Hoogle database. See:
       # https://github.com/input-output-hk/haskell.nix/issues/529
       shellHook = ''
         export HIE_HOOGLE_DATABASE="$(cat $(${super.which}/bin/which hoogle) | sed -n -e 's|.*--database \(.*\.hoo\).*|\1|p')"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,18 +23,6 @@
         "url": "https://github.com/hackworthltd/hacknix/archive/0dc2ac80cbfe7db750d450128fe5d65fb205f99d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "haskell-ide-engine": {
-        "branch": "master",
-        "description": "The engine for haskell ide-integration. Not an IDE",
-        "homepage": "",
-        "owner": "haskell",
-        "repo": "haskell-ide-engine",
-        "rev": "a9005b2ba2050bdfdd4438f1d471a3f7985492cd",
-        "sha256": "1gi512fvwb0imwwhs8l1b8vci84r08bpcwachyxcdlpdlyzlzacz",
-        "type": "tarball",
-        "url": "https://github.com/haskell/haskell-ide-engine/archive/a9005b2ba2050bdfdd4438f1d471a3f7985492cd.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "haskell-nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",


### PR DESCRIPTION
Reasons:

- haskell-language-server appears to be more or less usable now.

- hie isn't keeping up with new GHC versions anymore.

- hie development seems to be effectively halted.