### PR TITLE
Add an updated spago to our shell.

### DIFF
--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -104,12 +104,23 @@ let
       ];
     }));
 
+  # We need the latest version.
+  spago = args: (super.haskell-nix.project (args // rec {
+    name = "spago";
+    src = super.localLib.sources.spago;
+    projectFileName = "stack.yaml";
+    ignorePackageYaml = true;
+    sha256map = {
+      "https://github.com/f-f/haskell-with-utf8.git"."8ae743ac6503a4c494ea3bd52f1fe7d72f9f125d" = "sha256-vxI9AmaFxLn9kgQjaDhFbti/4KUyHoRslBwMa6WXtYE=";
+    };
+  }));
 
   extra-custom-tools = {
     hls.latest = args: (hls args).haskell-language-server.components.exes.haskell-language-server;
     hls-wrapper.latest = args: (hls args).haskell-language-server.components.exes.haskell-language-server-wrapper;
     cabal-fmt.latest = args: (cabal-fmt args).cabal-fmt.components.exes.cabal-fmt;
     purescript.latest = args: (purescript args).purescript.components.exes.purs;
+    spago.latest = args: (spago args).spago.components.exes.spago;
   };
 
 
@@ -124,6 +135,7 @@ let
     ormolu = super.haskell-nix.tool "ghc884" "ormolu" "0.1.3.0";
     cabal-edit = super.haskell-nix.tool "ghc8102" "cabal-edit" "0.1.0.0";
     purescript = super.haskell-nix.tool "ghc865" "purescript" "latest";
+    spago = super.haskell-nix.tool "ghc865" "spago" "latest";
   };
 
   ## Convenience wrappers for `haskell-nix.cabalProject`s.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -60,15 +60,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "spago": {
-        "branch": "master",
+        "branch": "no-download",
         "description": "🍝 PureScript package manager and build tool powered by Dhall and package-sets",
         "homepage": "",
-        "owner": "purescript",
+        "owner": "hackworthltd",
         "repo": "spago",
-        "rev": "f5c0fb6ac4ea9da7d19df91f8e828f0d6544b41b",
-        "sha256": "15yvklhr5mwnm9vyss6xfxy3887p0zp72jy31fjg24ghlndsgwmx",
+        "rev": "d17a0d8990fd7b5e1a6a7b1dd53bdfd57c3b4b72",
+        "sha256": "0ian3by91g2qwz7r9zbykxk44yk3v7s9ndl66wnkp0yw6yvmmkmz",
         "type": "tarball",
-        "url": "https://github.com/purescript/spago/archive/f5c0fb6ac4ea9da7d19df91f8e828f0d6544b41b.tar.gz",
+        "url": "https://github.com/hackworthltd/spago/archive/d17a0d8990fd7b5e1a6a7b1dd53bdfd57c3b4b72.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix": {
-        "branch": "master",
+        "branch": "macos-x509-system",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
-        "owner": "input-output-hk",
+        "owner": "hackworthltd",
         "repo": "haskell.nix",
-        "rev": "97765314b0f7c2d65f1964dd48cb4028d6580e60",
-        "sha256": "0qk4dwnyd3d1qg8ri9cyy2npm7ynaa70g3riq4mybdhnzlgp1748",
+        "rev": "e248a581694e6045c83a11d3a08a8c159d4ce62a",
+        "sha256": "01zqhixyzilhpkqa82glkpd1j7h0n06r7asxqr174bbq50qijbzq",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/97765314b0f7c2d65f1964dd48cb4028d6580e60.tar.gz",
+        "url": "https://github.com/hackworthltd/haskell.nix/archive/e248a581694e6045c83a11d3a08a8c159d4ce62a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -58,5 +58,17 @@
         "type": "tarball",
         "url": "https://github.com/purescript/purescript/archive/9cad73ed8ea7df3011032ddbd2f3de5a0c08629c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "spago": {
+        "branch": "master",
+        "description": "🍝 PureScript package manager and build tool powered by Dhall and package-sets",
+        "homepage": "",
+        "owner": "purescript",
+        "repo": "spago",
+        "rev": "f5c0fb6ac4ea9da7d19df91f8e828f0d6544b41b",
+        "sha256": "15yvklhr5mwnm9vyss6xfxy3887p0zp72jy31fjg24ghlndsgwmx",
+        "type": "tarball",
+        "url": "https://github.com/purescript/spago/archive/f5c0fb6ac4ea9da7d19df91f8e828f0d6544b41b.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This syncs with spago upstream trunk, and also fixes some Nix-related issues.