### PR TITLE
Set the haskell.nix nixpkgs input to follow our Big Sur fork for now.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     "badhosts": {
       "flake": false,
       "locked": {
-        "lastModified": 1609626791,
-        "narHash": "sha256-z2jZwHClXT8oXIBdqJKcNRT8ZN8TUVLdah6Jdz08RLs=",
+        "lastModified": 1609879183,
+        "narHash": "sha256-hci7jKMKItYWNwLKcSzkp7nzzQej6KF0y9ajEKx0Kho=",
         "owner": "StevenBlack",
         "repo": "hosts",
-        "rev": "91b65a8b7907feed32d5471eb4efad8817075a6f",
+        "rev": "b840587775066a6e91bcdcc649b036d9e9358879",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1609663211,
-        "narHash": "sha256-KHnlbQyEdUEj9kibcphWkr3dReEwkSk9+SXAmyX0uZM=",
+        "lastModified": 1609882615,
+        "narHash": "sha256-KsMSOiIIqnE8Y/tJuPrSsY22xzx4s92sFp1TaL2axf0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "474bafd0d5c59410afcd4d6f95b8e85a6781ff2c",
+        "rev": "e5278d70cc6ad94c3b1d13c9fa7eea19c1cc74ab",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1609246779,
-        "narHash": "sha256-eq6ZXE/VWo3EMC65jmIT6H/rrUc9UWOWVujkzav025k=",
+        "lastModified": 1609935452,
+        "narHash": "sha256-McwA/tAnnS8LaAdEoONBsdKFHuOpHMxKqpMCU1wL7H4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "08c7ad4a0844adc4a7f9f5bb3beae482e789afa4",
+        "rev": "8088c6dbe86a7e6e6396c83e43020e8a1edb08d5",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         "traefik-forward-auth": "traefik-forward-auth"
       },
       "locked": {
-        "lastModified": 1609697168,
-        "narHash": "sha256-LEmxr+t/UAAqbtMeuwa4NGsTX7QH37PZNCMmkx+XD6g=",
+        "lastModified": 1609949214,
+        "narHash": "sha256-AjLsYCUyNB3OeoReHMtO5O33ElgWkrtm9XpafA/eJXI=",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "16e450718fef92bbc51ecc3fddaf80245dac45a6",
+        "rev": "3e9391a3d1690925a5fdd06729ae32f1f5f71378",
         "type": "github"
       },
       "original": {
@@ -242,14 +242,16 @@
     },
     "haskell-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1609925209,
-        "narHash": "sha256-DLAGs0mVNFo/9ccyBlH1LC3ZbdgaMFmIZePQTMBhYH4=",
+        "lastModified": 1609956500,
+        "narHash": "sha256-QejYJ7b4IS/DQdaMukGI4GBYSpEH+k1hpF70X2sFXqs=",
         "owner": "hackworthltd",
         "repo": "haskell.nix",
-        "rev": "98c98d0ee1104a58c2fec2d6ceba320f07bdcfce",
+        "rev": "d384b5dff41c847d922a3a0c71b854eb4f0575b2",
         "type": "github"
       },
       "original": {
@@ -267,11 +269,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1605999746,
-        "narHash": "sha256-iurWIKPEza5ICsZOLVE1w6MoCohOqFifnedw/MafyI4=",
+        "lastModified": 1609854711,
+        "narHash": "sha256-eJfmyZTDJMusHIeMxsfhQNEDH6sTIuqiOYoM9MJdvGc=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "bde8d81876dfc02143e5070e42c78d8f0d83d6f7",
+        "rev": "be0aa7eb8589dc0b6ca92caa06a243c8163a04bd",
         "type": "github"
       },
       "original": {
@@ -338,11 +340,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1605715425,
-        "narHash": "sha256-h4VEpxnPBoUigXeoy0/8z8jUFKkJD9XG5dR/lt/rQCk=",
+        "lastModified": 1609520816,
+        "narHash": "sha256-IGO7tfJXsv9u2wpW76VCzOsHYapRZqH9pHGVsoffPrI=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "79aa7d95183cbe6c0d786965f0dbff414fd1aa67",
+        "rev": "8a2ce0f455da32bc20978e68c0aad9efb4560abc",
         "type": "github"
       },
       "original": {
@@ -393,7 +395,7 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1609520816,
@@ -457,22 +459,6 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1608007629,
-        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
         "lastModified": 1602702596,
         "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
         "owner": "NixOS",
@@ -486,7 +472,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1609634754,
         "narHash": "sha256-7Wj3xJRuc8dyGx5U3N8Q6kPznIkgPxP64FXv/Ua9YDc=",
@@ -527,7 +513,7 @@
         "hacknix": "hacknix",
         "haskell-nix": "haskell-nix",
         "hydra": "hydra_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "purescript": "purescript",
         "spago": "spago"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,10 @@
   description = "Hackworth Ltd's haskell.nix overlay.";
 
   inputs = {
+    nixpkgs.url = github:hackworthltd/nixpkgs/big-sur-fixes-v4;
     hacknix.url = github:hackworthltd/hacknix;
     haskell-nix.url = github:hackworthltd/haskell.nix/flakes-fixes-v2;
+    haskell-nix.inputs.nixpkgs.follows = "nixpkgs";
 
     flake-utils.url = github:numtide/flake-utils;
 
@@ -19,7 +21,6 @@
     spago.url = github:hackworthltd/spago;
     spago.flake = false;
 
-    nixpkgs.url = github:hackworthltd/nixpkgs/big-sur-fixes-v4;
     hydra.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
Needed until this is fixed:

https://github.com/input-output-hk/haskell.nix/issues/982