### PR TITLE
Bump dependencies.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "aws-export-credentials": {
       "flake": false,
       "locked": {
-        "lastModified": 1608408034,
-        "narHash": "sha256-qArAURSYluDpnpErtKqrhuSfi9mZ8y+1g+IW5AUA128=",
+        "lastModified": 1610462124,
+        "narHash": "sha256-kuWL2EpcQKOGaj4idLA/JQNSKHqqa82P3xiKZdoqe9w=",
         "owner": "benkehoe",
         "repo": "aws-export-credentials",
-        "rev": "7ea29781290184105252363402ff9bb4031801ca",
+        "rev": "967c0e5bc4db27f08446e15a14fadd8feb5ad0e9",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     "badhosts": {
       "flake": false,
       "locked": {
-        "lastModified": 1609879183,
-        "narHash": "sha256-hci7jKMKItYWNwLKcSzkp7nzzQej6KF0y9ajEKx0Kho=",
+        "lastModified": 1610474291,
+        "narHash": "sha256-QYRYEdU8i0YFtXzY/R0IOKyfrHoKfPEeqbHkJIdluOg=",
         "owner": "StevenBlack",
         "repo": "hosts",
-        "rev": "b840587775066a6e91bcdcc649b036d9e9358879",
+        "rev": "90eb6858cb1b0a40a09b41ab59acf53407b0725e",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1609882615,
-        "narHash": "sha256-KsMSOiIIqnE8Y/tJuPrSsY22xzx4s92sFp1TaL2axf0=",
+        "lastModified": 1610454128,
+        "narHash": "sha256-3Nq5J4M8/3k8FIM9aMZZQI6b02GM+matNctSilzGpYs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e5278d70cc6ad94c3b1d13c9fa7eea19c1cc74ab",
+        "rev": "31a92185a387a81809c4ee20d22ea2d2dff8ccac",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1609935452,
-        "narHash": "sha256-McwA/tAnnS8LaAdEoONBsdKFHuOpHMxKqpMCU1wL7H4=",
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "8088c6dbe86a7e6e6396c83e43020e8a1edb08d5",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1609246779,
-        "narHash": "sha256-eq6ZXE/VWo3EMC65jmIT6H/rrUc9UWOWVujkzav025k=",
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "08c7ad4a0844adc4a7f9f5bb3beae482e789afa4",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         "traefik-forward-auth": "traefik-forward-auth"
       },
       "locked": {
-        "lastModified": 1609949214,
-        "narHash": "sha256-AjLsYCUyNB3OeoReHMtO5O33ElgWkrtm9XpafA/eJXI=",
+        "lastModified": 1610548537,
+        "narHash": "sha256-JdLyx9TXJQjDTJDhtXvQRmpOFs92MjBXYtOwaEeeW6g=",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "3e9391a3d1690925a5fdd06729ae32f1f5f71378",
+        "rev": "cb42f79fb689de2d7d72d6c8ec565764b82d9480",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1609693522,
-        "narHash": "sha256-VRKdUeAyBLd1vuXLAh8ZMvsLrv0QyYHaek5YOeWggPA=",
+        "lastModified": 1610443370,
+        "narHash": "sha256-plFRrG2UR2R6BZ5RYE967jegLzpmF2tqof3j5rs7tBo=",
         "owner": "hackworthltd",
         "repo": "hacknix-lib",
-        "rev": "4f41a1dde964c854204879fbfe2f070ba1f58b9a",
+        "rev": "cd9d12451d28f12bcb766eaa125a0a254f28e2c8",
         "type": "github"
       },
       "original": {
@@ -412,11 +412,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1609574679,
-        "narHash": "sha256-PiNoISdoXCtRjdHapgDOwOYxaAdtRTked90hubk+x0Q=",
+        "lastModified": 1610340740,
+        "narHash": "sha256-TT2r/p9c4BazAogXOUgY8SPPzn7JaktL8AmzVy60HZM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2080afd039999a58d60596d04cefb32ef5fcc2a2",
+        "rev": "a67cfc0cdc10f218f2b9e0b153d1c31d5e96dded",
         "type": "github"
       },
       "original": {
@@ -443,11 +443,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1609634754,
-        "narHash": "sha256-7Wj3xJRuc8dyGx5U3N8Q6kPznIkgPxP64FXv/Ua9YDc=",
+        "lastModified": 1610474997,
+        "narHash": "sha256-ISMhNApPRsFFzLlMqcuQ/xcTcp5eQYa5avAu4ioPnAc=",
         "owner": "hackworthltd",
         "repo": "nixpkgs",
-        "rev": "191e3dd47d208e7ca313f3596cc514c5372be998",
+        "rev": "c8b32877874962d2d9b2e0278ca0643ae3d55f22",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1609634754,
-        "narHash": "sha256-7Wj3xJRuc8dyGx5U3N8Q6kPznIkgPxP64FXv/Ua9YDc=",
+        "lastModified": 1610474997,
+        "narHash": "sha256-ISMhNApPRsFFzLlMqcuQ/xcTcp5eQYa5avAu4ioPnAc=",
         "owner": "hackworthltd",
         "repo": "nixpkgs",
-        "rev": "191e3dd47d208e7ca313f3596cc514c5372be998",
+        "rev": "c8b32877874962d2d9b2e0278ca0643ae3d55f22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The hacknix nixpkgs pin contains a fix for the issue we're having
where the Nix closure for Haskell executables depends on GHC. See:

https://github.com/NixOS/nixpkgs/commit/61a6d1aae2f20ca7e714480907d87c6419ef1e80

Or at least, I hope this fixes the issue! Only way to find out is to
rebuild everything with this change.