### PR TITLE
Bump dependencies.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,7 @@
 -- Bump this to get newer package versions. In general, this should
 -- stay in sync with the latest package versions provided by upstream
 -- haskell.nix.
-index-state: 2021-02-21T00:00:00Z
+index-state: 2021-02-22T00:00:00Z
 
 packages:
   hhp/*.cabal

--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         "traefik-forward-auth": "traefik-forward-auth"
       },
       "locked": {
-        "lastModified": 1613869507,
-        "narHash": "sha256-8byE0UFRJoIB8NiAzFRsxAyIz0un79NO2QWVvkAPB58=",
+        "lastModified": 1614019360,
+        "narHash": "sha256-8HMKO3EyCgrDn6SwNCEW6e6E+1XXUt9YRitUaMG+mQw=",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "9918568f416d327543698fe0c708c93b8001951b",
+        "rev": "7f5aa652cf0c9bc5182e32b9912e0530124d6129",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1613779139,
-        "narHash": "sha256-mx40nS74/GM6yEDPlaRew3YpxQHquIUAyIeZRt6wU7k=",
+        "lastModified": 1613869375,
+        "narHash": "sha256-P8DVJdr3TjLTsvhUjkzu6nQiQULDKix7D7GFc76PEpk=",
         "owner": "hackworthltd",
         "repo": "hacknix-lib",
-        "rev": "a43f27ed7353b0a9793be4a1a410dc21c0f0bfa4",
+        "rev": "f176d4c6d72b5e51c9662681b87c51c72e4d80a7",
         "type": "github"
       },
       "original": {
@@ -212,19 +212,21 @@
     },
     "haskell-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2009": "nixpkgs-2009",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1613914012,
-        "narHash": "sha256-GLgkBaMXDq1RxxPGKqUsMnfrLN/X8p2PaqTlY8HaEsg=",
-        "owner": "hackworthltd",
+        "lastModified": 1613996756,
+        "narHash": "sha256-J6JbKCqzpJhlHT3+44vjcvkoX1qJSzOzM31xpS38ysY=",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a11e14d2e03c9d4fe970c67a41ffc26bf503c590",
+        "rev": "c4e5aea19b2436670524a230a0e5e959c8923fd1",
         "type": "github"
       },
       "original": {
-        "owner": "hackworthltd",
-        "ref": "flake-fixes-v6",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
         "type": "github"
       }
@@ -326,17 +328,65 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1613744885,
-        "narHash": "sha256-7gSYJmC4vD/teQudpX/L1fRv+7s0GAO4TbLUYWUqWs8=",
+        "lastModified": 1613802177,
+        "narHash": "sha256-KArRn6+roF0XaL6vti3GcfE47FxWG1SnJrBkXWpS1uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e88bfd7c92849e4da5dd8dbed0f06b46261e3c72",
+        "rev": "a964d7094a30316f0f25dbe6dad5fb8b1878f57c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1607708579,
+        "narHash": "sha256-QyADEDydJJPa8n3xawnA82IJAcZHNNm6Pp5DU7exMr4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2009": {
+      "locked": {
+        "lastModified": 1608007629,
+        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1612284693,
+        "narHash": "sha256-efzJNF1jvjK3BMl0gZ0ZaUWcFMv0nLb9AHN/++5+u0U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
         "type": "github"
       }
     },
@@ -357,17 +407,17 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1612284693,
-        "narHash": "sha256-efzJNF1jvjK3BMl0gZ0ZaUWcFMv0nLb9AHN/++5+u0U=",
+        "lastModified": 1608007629,
+        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
         "type": "github"
       }
     },
@@ -380,7 +430,7 @@
         "haskell-nix": "haskell-nix",
         "nixpkgs": [
           "haskell-nix",
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "Hackworth Ltd's haskell.nix overlay.";
 
   inputs = {
-    haskell-nix.url = github:hackworthltd/haskell.nix/flake-fixes-v6;
-    nixpkgs.follows = "haskell-nix/nixpkgs";
+    haskell-nix.url = github:input-output-hk/haskell.nix;
+    nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
     hacknix.url = github:hackworthltd/hacknix;
     hacknix.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -4,7 +4,7 @@ let
     (final.haskell-nix.cabalProject (args // rec {
       # Note: cabal-fmt doesn't provide its own index-state, so we
       # choose one for it here.
-      index-state = "2021-02-21T00:00:00Z";
+      index-state = "2021-02-22T00:00:00Z";
 
       name = "cabal-fmt";
 


### PR DESCRIPTION
Upstream haskell.nix now has a working flake, so we can drop ours.

Also bump hackage index.